### PR TITLE
fix: make all releases manual instead of automated

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,9 +1,6 @@
 name: Beta Release
 
 on:
-  schedule:
-    # Every Monday at 9 AM UTC
-    - cron: '0 9 * * 1'
   workflow_dispatch:
     inputs:
       version_type:

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -6,9 +6,6 @@ on:
     types: [published]
   # Manual trigger
   workflow_dispatch:
-  # Run daily to catch any drift
-  schedule:
-    - cron: '0 0 * * *'
 
 permissions:
   contents: write

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,7 +13,7 @@ This document describes the release management process for this project.
 ### 🧪 Beta (`beta` branch)
 - **Purpose**: Testing and early access
 - **Stability**: Mostly stable, suitable for testing
-- **Updates**: Weekly (every Monday)
+- **Updates**: Manual (as needed for testing)
 - **Use when**: You want early access to new features with reasonable stability
 
 ### ✅ Stable (`stable` branch)
@@ -87,10 +87,10 @@ We follow [Semantic Versioning](https://semver.org/):
 ## Release Schedule
 
 ### Beta Releases
-- **When**: Every Monday at 9:00 AM UTC
+- **When**: Manual trigger when ready for testing
 - **What**: All changes from main branch
 - **Version**: Automatic bump based on conventional commits
-- **Testing**: One week testing period before stable promotion
+- **Testing**: Testing period before stable promotion
 
 ### Stable Releases
 - **When**: Monthly or when critical fixes are needed
@@ -144,10 +144,10 @@ Use /api/v2/users instead.
 
 ## Release Process
 
-### 1. Beta Release (Automated)
+### 1. Beta Release (Manual)
 ```mermaid
 graph LR
-    A[Monday 9AM UTC] --> B[Analyze Commits]
+    A[Trigger Workflow] --> B[Analyze Commits]
     B --> C[Determine Version]
     C --> D[Merge main → beta]
     D --> E[Tag Beta Version]

--- a/templates/.github/workflows/release-beta.yml
+++ b/templates/.github/workflows/release-beta.yml
@@ -1,9 +1,6 @@
 name: Beta Release
 
 on:
-  schedule:
-    # Every Monday at 9 AM UTC
-    - cron: '0 9 * * 1'
   workflow_dispatch:
     inputs:
       version_type:

--- a/templates/.github/workflows/sync-branches.yml
+++ b/templates/.github/workflows/sync-branches.yml
@@ -6,9 +6,6 @@ on:
     types: [published]
   # Manual trigger
   workflow_dispatch:
-  # Run daily to catch any drift
-  schedule:
-    - cron: '0 0 * * *'
 
 permissions:
   contents: write

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -79,8 +79,8 @@ Use these prefixes for automatic versioning:
 - `docs:`, `style:`, `refactor:`, `test:`, `chore:` (no release)
 
 #### Release Schedule
-- **Beta**: Every Monday (automated)
-- **Stable**: Monthly or as needed (manual)
+- **Beta**: Manual (when ready for testing)
+- **Stable**: Manual (after beta validation)
 - **Hotfix**: As needed for critical issues
 
 ## Active Issues

--- a/templates/RELEASES.md
+++ b/templates/RELEASES.md
@@ -13,7 +13,7 @@ This document describes the release management process for this project.
 ### 🧪 Beta (`beta` branch)
 - **Purpose**: Testing and early access
 - **Stability**: Mostly stable, suitable for testing
-- **Updates**: Weekly (every Monday)
+- **Updates**: Manual (as needed for testing)
 - **Use when**: You want early access to new features with reasonable stability
 
 ### ✅ Stable (`stable` branch)
@@ -87,10 +87,10 @@ We follow [Semantic Versioning](https://semver.org/):
 ## Release Schedule
 
 ### Beta Releases
-- **When**: Every Monday at 9:00 AM UTC
+- **When**: Manual trigger when ready for testing
 - **What**: All changes from main branch
 - **Version**: Automatic bump based on conventional commits
-- **Testing**: One week testing period before stable promotion
+- **Testing**: Testing period before stable promotion
 
 ### Stable Releases
 - **When**: Monthly or when critical fixes are needed
@@ -144,10 +144,10 @@ Use /api/v2/users instead.
 
 ## Release Process
 
-### 1. Beta Release (Automated)
+### 1. Beta Release (Manual)
 ```mermaid
 graph LR
-    A[Monday 9AM UTC] --> B[Analyze Commits]
+    A[Trigger Workflow] --> B[Analyze Commits]
     B --> C[Determine Version]
     C --> D[Merge main → beta]
     D --> E[Tag Beta Version]


### PR DESCRIPTION
## Overview

This PR updates the release system to make both beta and stable releases manual instead of having automated weekly beta releases.

## Changes

### Workflow Updates
- Removed scheduled trigger from `release-beta.yml` (both in `.github/workflows/` and `templates/`)
- Removed daily schedule from `sync-branches.yml` 
- Both beta and stable releases now require manual workflow dispatch

### Documentation Updates
- Updated RELEASES.md to reflect manual beta releases
- Changed all references from "weekly" to "manual" 
- Updated release schedule documentation

## Rationale

Manual releases provide better control over:
- When to create beta releases based on feature completeness
- Testing cycles that aren't tied to a fixed schedule
- Version management aligned with actual development pace

## Testing

- [x] Workflow files are valid
- [x] Documentation is consistent
- [x] No automated triggers remain

---

This ensures releases happen when the project is ready, not on an arbitrary schedule.